### PR TITLE
Added soldermaskmargin to tooling information

### DIFF
--- a/example/identical-size-panel/preset.json
+++ b/example/identical-size-panel/preset.json
@@ -77,6 +77,7 @@
         "voffset": "2mm",
         "size": "2mm",
         "paste": false,
+        "soldermaskmargin": "0mm",
         "code": "none",
         "arg": ""
     },


### PR DESCRIPTION
Fixes Issue #9 by specifying the soldermask margin in the tooling section of the preset.
Set to 0mm to not interfere with any other values.